### PR TITLE
Add AutoAssignInternal plugin

### DIFF
--- a/autoassigninternal/front/config.form.php
+++ b/autoassigninternal/front/config.form.php
@@ -1,0 +1,37 @@
+<?php
+
+include '../../../inc/includes.php';
+
+Session::checkRight('config', UPDATE);
+
+$config = new PluginAutoassigninternalConfig();
+if (!$config->getFromDB(PluginAutoassigninternalConfig::CONFIG_ID)) {
+    $config->add([
+        'id'              => PluginAutoassigninternalConfig::CONFIG_ID,
+        'requesttypes_id' => 0
+    ]);
+    $config->getFromDB(PluginAutoassigninternalConfig::CONFIG_ID);
+}
+
+if (isset($_POST['update'])) {
+    $input = [
+        'id' => PluginAutoassigninternalConfig::CONFIG_ID
+    ];
+
+    if (isset($_POST['requesttypes_id']) && $_POST['requesttypes_id'] !== '') {
+        $input['requesttypes_id'] = (int)$_POST['requesttypes_id'];
+    } else {
+        $input['requesttypes_id'] = 0;
+    }
+
+    $config->update($input);
+    Session::addMessageAfterRedirect(__('Configuration updated', 'autoassigninternal'), true, INFO, true);
+    Html::back();
+    exit;
+}
+
+Html::header(__('Auto Assign Internal', 'autoassigninternal'), '', 'plugins', 'autoassigninternal');
+
+$config->showConfigForm();
+
+Html::footer();

--- a/autoassigninternal/hook.php
+++ b/autoassigninternal/hook.php
@@ -1,0 +1,73 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Direct access not allowed');
+}
+
+require_once __DIR__ . '/inc/config.class.php';
+
+function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
+    if (!($item instanceof TicketTask)) {
+        return;
+    }
+
+    if (!isset($item->input) || !is_array($item->input)) {
+        return;
+    }
+
+    if (!isset($item->input['users_id'])) {
+        return;
+    }
+
+    $taskUserId = (int)$item->input['users_id'];
+    if ($taskUserId <= 0) {
+        return;
+    }
+
+    $ticketId = 0;
+    if (isset($item->fields) && isset($item->fields['tickets_id'])) {
+        $ticketId = (int)$item->fields['tickets_id'];
+    }
+    if ($ticketId <= 0 && isset($item->input['tickets_id'])) {
+        $ticketId = (int)$item->input['tickets_id'];
+    }
+    if ($ticketId <= 0) {
+        return;
+    }
+
+    $config = PluginAutoassigninternalConfig::getInstance();
+    $internalRequestTypeId = $config->getInternalRequestTypeId();
+    if ($internalRequestTypeId <= 0) {
+        return;
+    }
+
+    $ticket = new Ticket();
+    if (!$ticket->getFromDB($ticketId)) {
+        return;
+    }
+
+    if (!isset($ticket->fields['requesttypes_id']) || (int)$ticket->fields['requesttypes_id'] !== (int)$internalRequestTypeId) {
+        return;
+    }
+
+    $assignmentField = 'users_id';
+    if (!isset($ticket->fields[$assignmentField]) && isset($ticket->fields['users_id_assign'])) {
+        $assignmentField = 'users_id_assign';
+    }
+
+    $currentTicketUserId = 0;
+    if (isset($ticket->fields[$assignmentField])) {
+        $currentTicketUserId = (int)$ticket->fields[$assignmentField];
+    }
+
+    if ($currentTicketUserId === $taskUserId) {
+        return;
+    }
+
+    $updateInput = [
+        'id'             => $ticketId,
+        $assignmentField => $taskUserId
+    ];
+
+    $ticket->update($updateInput);
+}

--- a/autoassigninternal/inc/config.class.php
+++ b/autoassigninternal/inc/config.class.php
@@ -1,0 +1,81 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Direct access not allowed');
+}
+
+class PluginAutoassigninternalConfig extends CommonDBTM {
+    public static $rightname = 'config';
+
+    const CONFIG_ID = 1;
+
+    public $dohistory = true;
+
+    public static function getTypeName($nb = 0) {
+        return _n('Auto Assign Internal', 'Auto Assign Internal', $nb, 'autoassigninternal');
+    }
+
+    public static function getInstance() {
+        $instance = new self();
+        if (!$instance->getFromDB(self::CONFIG_ID)) {
+            $instance->fields = [
+                'id'              => self::CONFIG_ID,
+                'requesttypes_id' => 0
+            ];
+        }
+
+        return $instance;
+    }
+
+    public function getInternalRequestTypeId() {
+        if (isset($this->fields['requesttypes_id'])) {
+            return (int)$this->fields['requesttypes_id'];
+        }
+        return 0;
+    }
+
+    public function showConfigForm() {
+        $this->initForm(self::CONFIG_ID);
+        $this->showFormHeader(['formtitle' => self::getTypeName(1)]);
+
+        echo "<tr class='tab_bg_1'>";
+        echo '<td>' . __('Internal request type', 'autoassigninternal') . '</td>';
+        echo '<td>';
+
+        $value = 0;
+        if (isset($this->fields['requesttypes_id'])) {
+            $value = (int)$this->fields['requesttypes_id'];
+        }
+
+        RequestType::dropdown([
+            'name'                 => 'requesttypes_id',
+            'value'                => $value,
+            'display_emptychoice'  => true
+        ]);
+
+        echo '</td>';
+        echo '</tr>';
+
+        $this->showFormButtons(['candel' => false]);
+
+        return true;
+    }
+
+    public function prepareInputForAdd($input) {
+        if (!isset($input['requesttypes_id'])) {
+            $input['requesttypes_id'] = 0;
+        }
+        $input['requesttypes_id'] = (int)$input['requesttypes_id'];
+
+        return parent::prepareInputForAdd($input);
+    }
+
+    public function prepareInputForUpdate($input) {
+        if (!isset($input['requesttypes_id'])) {
+            $input['requesttypes_id'] = 0;
+        }
+        $input['requesttypes_id'] = (int)$input['requesttypes_id'];
+
+        return parent::prepareInputForUpdate($input);
+    }
+}

--- a/autoassigninternal/setup.php
+++ b/autoassigninternal/setup.php
@@ -1,0 +1,79 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Direct access not allowed');
+}
+
+require_once __DIR__ . '/inc/config.class.php';
+
+function plugin_init_autoassigninternal() {
+    global $PLUGIN_HOOKS;
+
+    $PLUGIN_HOOKS['post_item_update']['autoassigninternal'] = 'plugin_autoassigninternal_post_item_update';
+    $PLUGIN_HOOKS['config_page']['autoassigninternal'] = 'front/config.form.php';
+    $PLUGIN_HOOKS['csrf_compliant']['autoassigninternal'] = true;
+
+    if (class_exists('Plugin')) {
+        Plugin::registerClass('PluginAutoassigninternalConfig');
+    }
+}
+
+function plugin_version_autoassigninternal() {
+    return [
+        'name'           => __('Auto Assign Internal', 'autoassigninternal'),
+        'version'        => '1.0.0',
+        'author'         => 'OpenAI ChatGPT',
+        'license'        => 'GPLv2+',
+        'homepage'       => '',
+        'minGlpiVersion' => '9.5.5',
+        'maxGlpiVersion' => '9.5.x'
+    ];
+}
+
+function plugin_autoassigninternal_check_prerequisites() {
+    if (version_compare(GLPI_VERSION, '9.5.5', '<')) {
+        echo __('This plugin requires GLPI 9.5.5 or higher.', 'autoassigninternal');
+        return false;
+    }
+    return true;
+}
+
+function plugin_autoassigninternal_check_config($verbose = false) {
+    return true;
+}
+
+function plugin_autoassigninternal_install() {
+    global $DB;
+
+    $table = 'glpi_plugin_autoassigninternal_configs';
+
+    if (!$DB->tableExists($table)) {
+        $query = "CREATE TABLE `$table` (
+            `id` int(11) NOT NULL AUTO_INCREMENT,
+            `requesttypes_id` int(11) NOT NULL DEFAULT '0',
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+        $DB->queryOrDie($query, 'Failed to create plugin_autoassigninternal configuration table');
+    }
+
+    $config = new PluginAutoassigninternalConfig();
+    if (!$config->getFromDB(1)) {
+        $config->add([
+            'id'              => 1,
+            'requesttypes_id' => 0
+        ]);
+    }
+
+    return true;
+}
+
+function plugin_autoassigninternal_uninstall() {
+    global $DB;
+
+    $table = 'glpi_plugin_autoassigninternal_configs';
+    if ($DB->tableExists($table)) {
+        $DB->query("DROP TABLE `$table`");
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- add the AutoAssignInternal plugin to intercept ticket task updates and sync ticket assignment when the configured internal request type is used
- provide a plugin configuration form so administrators can choose which request type should trigger automatic assignment
- register plugin metadata, installation, and CSRF compliance for GLPI 9.5.5

## Testing
- php -l autoassigninternal/setup.php
- php -l autoassigninternal/hook.php
- php -l autoassigninternal/inc/config.class.php
- php -l autoassigninternal/front/config.form.php

------
https://chatgpt.com/codex/tasks/task_e_68dd6cd5b5d48331994966c7061ca5b2