### PR TITLE
Add logging and Portuguese UI for multi-source auto assignment

### DIFF
--- a/autoassigninternal/front/config.form.php
+++ b/autoassigninternal/front/config.form.php
@@ -7,8 +7,8 @@ Session::checkRight('config', UPDATE);
 $config = new PluginAutoassigninternalConfig();
 if (!$config->getFromDB(PluginAutoassigninternalConfig::CONFIG_ID)) {
     $config->add([
-        'id'              => PluginAutoassigninternalConfig::CONFIG_ID,
-        'requesttypes_id' => 0
+        'id'           => PluginAutoassigninternalConfig::CONFIG_ID,
+        'requesttypes' => json_encode([])
     ]);
     $config->getFromDB(PluginAutoassigninternalConfig::CONFIG_ID);
 }
@@ -18,19 +18,19 @@ if (isset($_POST['update'])) {
         'id' => PluginAutoassigninternalConfig::CONFIG_ID
     ];
 
-    if (isset($_POST['requesttypes_id']) && $_POST['requesttypes_id'] !== '') {
-        $input['requesttypes_id'] = (int)$_POST['requesttypes_id'];
+    if (isset($_POST['requesttypes_ids']) && is_array($_POST['requesttypes_ids'])) {
+        $input['requesttypes'] = $_POST['requesttypes_ids'];
     } else {
-        $input['requesttypes_id'] = 0;
+        $input['requesttypes'] = [];
     }
 
     $config->update($input);
-    Session::addMessageAfterRedirect(__('Configuration updated', 'autoassigninternal'), true, INFO, true);
+    Session::addMessageAfterRedirect(__('Configuração atualizada com sucesso.', 'autoassigninternal'), true, INFO, true);
     Html::back();
     exit;
 }
 
-Html::header(__('Auto Assign Internal', 'autoassigninternal'), '', 'plugins', 'autoassigninternal');
+Html::header(__('Atribuição Interna Automática', 'autoassigninternal'), '', 'plugins', 'autoassigninternal');
 
 $config->showConfigForm();
 

--- a/autoassigninternal/hook.php
+++ b/autoassigninternal/hook.php
@@ -6,21 +6,33 @@ if (!defined('GLPI_ROOT')) {
 
 require_once __DIR__ . '/inc/config.class.php';
 
+if (!function_exists('plugin_autoassigninternal_log')) {
+    function plugin_autoassigninternal_log($message) {
+        Toolbox::logInFile('autoassigninternal', '[AutoAssignInternal] ' . $message);
+    }
+}
+
 function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
     if (!($item instanceof TicketTask)) {
         return;
     }
 
+    $taskId = (int)$item->getID();
+    plugin_autoassigninternal_log(sprintf('Tarefa %d atualizada.', $taskId));
+
     if (!isset($item->input) || !is_array($item->input)) {
+        plugin_autoassigninternal_log('Nenhuma entrada disponível para a tarefa, atribuição ignorada.');
         return;
     }
 
     if (!isset($item->input['users_id'])) {
+        plugin_autoassigninternal_log('Tarefa sem usuário atribuído, nada a fazer.');
         return;
     }
 
     $taskUserId = (int)$item->input['users_id'];
     if ($taskUserId <= 0) {
+        plugin_autoassigninternal_log('Usuário atribuído inválido para a tarefa.');
         return;
     }
 
@@ -32,21 +44,31 @@ function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
         $ticketId = (int)$item->input['tickets_id'];
     }
     if ($ticketId <= 0) {
+        plugin_autoassigninternal_log('Não foi possível identificar o chamado relacionado à tarefa.');
         return;
     }
 
     $config = PluginAutoassigninternalConfig::getInstance();
-    $internalRequestTypeId = $config->getInternalRequestTypeId();
-    if ($internalRequestTypeId <= 0) {
+    $internalRequestTypeIds = $config->getInternalRequestTypeIds();
+    if (empty($internalRequestTypeIds)) {
+        plugin_autoassigninternal_log('Nenhum tipo de origem configurado para atribuição automática.');
         return;
     }
 
     $ticket = new Ticket();
     if (!$ticket->getFromDB($ticketId)) {
+        plugin_autoassigninternal_log(sprintf('Chamado %d não encontrado.', $ticketId));
         return;
     }
 
-    if (!isset($ticket->fields['requesttypes_id']) || (int)$ticket->fields['requesttypes_id'] !== (int)$internalRequestTypeId) {
+    if (!isset($ticket->fields['requesttypes_id'])) {
+        plugin_autoassigninternal_log(sprintf('Chamado %d sem tipo de origem definido.', $ticketId));
+        return;
+    }
+
+    $ticketRequestTypeId = (int)$ticket->fields['requesttypes_id'];
+    if (!in_array($ticketRequestTypeId, $internalRequestTypeIds, true)) {
+        plugin_autoassigninternal_log(sprintf('Chamado %d com origem %d não está configurado para atribuição automática.', $ticketId, $ticketRequestTypeId));
         return;
     }
 
@@ -61,6 +83,7 @@ function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
     }
 
     if ($currentTicketUserId === $taskUserId) {
+        plugin_autoassigninternal_log(sprintf('Chamado %d já está atribuído ao usuário %d.', $ticketId, $taskUserId));
         return;
     }
 
@@ -69,5 +92,9 @@ function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
         $assignmentField => $taskUserId
     ];
 
-    $ticket->update($updateInput);
+    if ($ticket->update($updateInput)) {
+        plugin_autoassigninternal_log(sprintf('Chamado %d atribuído automaticamente ao usuário %d.', $ticketId, $taskUserId));
+    } else {
+        plugin_autoassigninternal_log(sprintf('Falha ao atribuir automaticamente o chamado %d ao usuário %d.', $ticketId, $taskUserId));
+    }
 }


### PR DESCRIPTION
## Summary
- allow configuring multiple request types for automatic assignment with a Portuguese-facing configuration form
- add detailed logging so task updates report why automatic assignment succeeded or was skipped
- migrate the plugin configuration table to store multiple request types and bump the plugin version to 1.1.0

## Testing
- php -l autoassigninternal/inc/config.class.php
- php -l autoassigninternal/front/config.form.php
- php -l autoassigninternal/hook.php
- php -l autoassigninternal/setup.php

------
https://chatgpt.com/codex/tasks/task_e_68dd74de4bc08331a6e42f7460232798