### PR TITLE
Fix request type dropdown warning for auto assign plugin

### DIFF
--- a/autoassigninternal/inc/config.class.php
+++ b/autoassigninternal/inc/config.class.php
@@ -55,13 +55,18 @@ class PluginAutoassigninternalConfig extends CommonDBTM {
 
         $value = $this->getInternalRequestTypeIds();
 
-        RequestType::dropdown([
+        $params = [
             'name'                => 'requesttypes_ids[]',
-            'value'               => $value,
             'values'              => $value,
             'multiple'            => true,
             'display_emptychoice' => true
-        ]);
+        ];
+
+        if (!empty($value)) {
+            $params['value'] = (string) reset($value);
+        }
+
+        RequestType::dropdown($params);
 
         echo '</td>';
         echo '</tr>';


### PR DESCRIPTION
## Summary
- avoid passing an array to the dropdown value parameter to prevent PHP warnings
- retain preselected request types when rendering the configuration form

## Testing
- php -l autoassigninternal/inc/config.class.php

------
https://chatgpt.com/codex/tasks/task_e_68dd777a4f4c8331943e20f137cbdd14