### PR TITLE
Synchronize ticket assignee when tasks change

### DIFF
--- a/autoassigninternal/hook.php
+++ b/autoassigninternal/hook.php
@@ -5,48 +5,37 @@ if (!defined('GLPI_ROOT')) {
 }
 
 require_once __DIR__ . '/inc/config.class.php';
+require_once __DIR__ . '/inc/logging.php';
 
-if (!function_exists('plugin_autoassigninternal_log')) {
-    function plugin_autoassigninternal_log($message) {
-        Toolbox::logInFile('autoassigninternal', '[AutoAssignInternal] ' . $message);
-    }
+function plugin_autoassigninternal_post_item_add(CommonDBTM $item) {
+    plugin_autoassigninternal_handle_task_event($item, 'add');
 }
 
 function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
+    plugin_autoassigninternal_handle_task_event($item, 'update');
+}
+
+function plugin_autoassigninternal_handle_task_event(CommonDBTM $item, $event) {
     if (!($item instanceof TicketTask)) {
         return;
     }
 
     $taskId = (int)$item->getID();
-    plugin_autoassigninternal_log(sprintf('Tarefa %d atualizada.', $taskId));
+    plugin_autoassigninternal_log(sprintf('Processando tarefa %d após %s.', $taskId, $event));
 
-    if (!isset($item->input) || !is_array($item->input)) {
-        plugin_autoassigninternal_log('Nenhuma entrada disponível para a tarefa, atribuição ignorada.');
-        return;
-    }
-
-    if (!isset($item->input['users_id'])) {
-        plugin_autoassigninternal_log('Tarefa sem usuário atribuído, nada a fazer.');
-        return;
-    }
-
-    $taskUserId = (int)$item->input['users_id'];
+    $taskUserId = plugin_autoassigninternal_resolve_task_user($item);
     if ($taskUserId <= 0) {
-        plugin_autoassigninternal_log('Usuário atribuído inválido para a tarefa.');
+        plugin_autoassigninternal_log('Não foi possível identificar o técnico atribuído à tarefa.');
         return;
     }
 
-    $ticketId = 0;
-    if (isset($item->fields) && isset($item->fields['tickets_id'])) {
-        $ticketId = (int)$item->fields['tickets_id'];
-    }
-    if ($ticketId <= 0 && isset($item->input['tickets_id'])) {
-        $ticketId = (int)$item->input['tickets_id'];
-    }
+    $ticketId = plugin_autoassigninternal_resolve_ticket_id($item);
     if ($ticketId <= 0) {
         plugin_autoassigninternal_log('Não foi possível identificar o chamado relacionado à tarefa.');
         return;
     }
+
+    plugin_autoassigninternal_log(sprintf('Tarefa %d vinculada ao chamado %d com técnico %d.', $taskId, $ticketId, $taskUserId));
 
     $config = PluginAutoassigninternalConfig::getInstance();
     $internalRequestTypeIds = $config->getInternalRequestTypeIds();
@@ -61,40 +50,150 @@ function plugin_autoassigninternal_post_item_update(CommonDBTM $item) {
         return;
     }
 
-    if (!isset($ticket->fields['requesttypes_id'])) {
+    $ticketRequestTypeId = (int)($ticket->fields['requesttypes_id'] ?? 0);
+    if ($ticketRequestTypeId <= 0) {
         plugin_autoassigninternal_log(sprintf('Chamado %d sem tipo de origem definido.', $ticketId));
         return;
     }
 
-    $ticketRequestTypeId = (int)$ticket->fields['requesttypes_id'];
     if (!in_array($ticketRequestTypeId, $internalRequestTypeIds, true)) {
-        plugin_autoassigninternal_log(sprintf('Chamado %d com origem %d não está configurado para atribuição automática.', $ticketId, $ticketRequestTypeId));
+        plugin_autoassigninternal_log(sprintf('Chamado %d com origem %d não está configurado para atribuição automática (configurados: %s).', $ticketId, $ticketRequestTypeId, implode(', ', $internalRequestTypeIds)));
         return;
     }
 
-    $assignmentField = 'users_id';
-    if (!isset($ticket->fields[$assignmentField]) && isset($ticket->fields['users_id_assign'])) {
-        $assignmentField = 'users_id_assign';
-    }
+    $ticketUser = new Ticket_User();
+    $assignType = CommonITILActor::ASSIGN;
+    $existingAssignments = $ticketUser->find([
+        'tickets_id' => $ticketId,
+        'type'       => $assignType
+    ], 'id ASC');
 
-    $currentTicketUserId = 0;
-    if (isset($ticket->fields[$assignmentField])) {
-        $currentTicketUserId = (int)$ticket->fields[$assignmentField];
-    }
-
-    if ($currentTicketUserId === $taskUserId) {
-        plugin_autoassigninternal_log(sprintf('Chamado %d já está atribuído ao usuário %d.', $ticketId, $taskUserId));
-        return;
-    }
-
-    $updateInput = [
-        'id'             => $ticketId,
-        $assignmentField => $taskUserId
-    ];
-
-    if ($ticket->update($updateInput)) {
-        plugin_autoassigninternal_log(sprintf('Chamado %d atribuído automaticamente ao usuário %d.', $ticketId, $taskUserId));
+    if (is_array($existingAssignments)) {
+        foreach ($existingAssignments as $assignment) {
+            if ((int)$assignment['users_id'] === $taskUserId) {
+                plugin_autoassigninternal_log(sprintf('Chamado %d já está atribuído ao usuário %d.', $ticketId, $taskUserId));
+                return;
+            }
+        }
     } else {
-        plugin_autoassigninternal_log(sprintf('Falha ao atribuir automaticamente o chamado %d ao usuário %d.', $ticketId, $taskUserId));
+        $existingAssignments = [];
     }
+
+    $result = false;
+
+    if (!empty($existingAssignments)) {
+        $assignment    = reset($existingAssignments);
+        $assignmentKey = key($existingAssignments);
+        $assignmentId  = 0;
+
+        if (isset($assignment['id'])) {
+            $assignmentId = (int)$assignment['id'];
+        }
+
+        if ($assignmentId <= 0 && $assignmentKey !== null) {
+            $assignmentId = (int)$assignmentKey;
+        }
+
+        if ($assignmentId <= 0) {
+            plugin_autoassigninternal_log(sprintf('Não foi possível determinar o registro de atribuição existente para o chamado %d.', $ticketId));
+            return;
+        }
+
+        $updateData = [
+            'id'               => $assignmentId,
+            'tickets_id'       => $ticketId,
+            'type'             => $assignType,
+            'users_id'         => $taskUserId,
+            'use_notification' => isset($assignment['use_notification']) ? (int)$assignment['use_notification'] : 1
+        ];
+
+        $result = (bool)$ticketUser->update($updateData);
+        if ($result) {
+            plugin_autoassigninternal_log(sprintf('Chamado %d atualizado para o usuário %d (registro %d).', $ticketId, $taskUserId, $assignmentId));
+        }
+    } else {
+        $addData = [
+            'tickets_id'       => $ticketId,
+            'users_id'         => $taskUserId,
+            'type'             => $assignType,
+            'use_notification' => 1
+        ];
+
+        $result = (bool)$ticketUser->add($addData);
+        if ($result) {
+            plugin_autoassigninternal_log(sprintf('Chamado %d atribuído automaticamente ao usuário %d (novo registro).', $ticketId, $taskUserId));
+        }
+    }
+
+    if (!$result) {
+        plugin_autoassigninternal_log(sprintf('Falha ao sincronizar a atribuição do chamado %d para o usuário %d.', $ticketId, $taskUserId));
+    }
+}
+
+function plugin_autoassigninternal_resolve_task_user(TicketTask $task) {
+    $candidates = [];
+
+    if (isset($task->fields['users_id_tech'])) {
+        $candidates[] = $task->fields['users_id_tech'];
+    }
+    if (isset($task->input['users_id_tech'])) {
+        $candidates[] = $task->input['users_id_tech'];
+    }
+    if (isset($task->fields['users_id'])) {
+        $candidates[] = $task->fields['users_id'];
+    }
+    if (isset($task->input['users_id'])) {
+        $candidates[] = $task->input['users_id'];
+    }
+
+    foreach ($candidates as $candidate) {
+        $candidate = (int)$candidate;
+        if ($candidate > 0) {
+            return $candidate;
+        }
+    }
+
+    $taskId = (int)$task->getID();
+    if ($taskId > 0) {
+        $freshTask = new TicketTask();
+        if ($freshTask->getFromDB($taskId)) {
+            $candidate = (int)($freshTask->fields['users_id_tech'] ?? 0);
+            if ($candidate > 0) {
+                return $candidate;
+            }
+        }
+    }
+
+    return 0;
+}
+
+function plugin_autoassigninternal_resolve_ticket_id(TicketTask $task) {
+    $candidates = [];
+
+    if (isset($task->fields['tickets_id'])) {
+        $candidates[] = $task->fields['tickets_id'];
+    }
+    if (isset($task->input['tickets_id'])) {
+        $candidates[] = $task->input['tickets_id'];
+    }
+
+    foreach ($candidates as $candidate) {
+        $candidate = (int)$candidate;
+        if ($candidate > 0) {
+            return $candidate;
+        }
+    }
+
+    $taskId = (int)$task->getID();
+    if ($taskId > 0) {
+        $freshTask = new TicketTask();
+        if ($freshTask->getFromDB($taskId)) {
+            $candidate = (int)($freshTask->fields['tickets_id'] ?? 0);
+            if ($candidate > 0) {
+                return $candidate;
+            }
+        }
+    }
+
+    return 0;
 }

--- a/autoassigninternal/inc/logging.php
+++ b/autoassigninternal/inc/logging.php
@@ -1,0 +1,49 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Direct access not allowed');
+}
+
+if (!function_exists('plugin_autoassigninternal_log')) {
+    function plugin_autoassigninternal_log($message) {
+        $prefix = '[AutoAssignInternal] ';
+        $line   = $prefix . $message;
+
+        $logDir = defined('GLPI_LOG_DIR') ? GLPI_LOG_DIR : GLPI_ROOT . '/files/_log';
+        $logDir = rtrim($logDir, DIRECTORY_SEPARATOR);
+        $logFile = $logDir . DIRECTORY_SEPARATOR . 'autoassigninternal.log';
+
+        $sizeBefore = null;
+        if (file_exists($logFile)) {
+            clearstatcache(true, $logFile);
+            $sizeBefore = filesize($logFile);
+        }
+
+        $wroteWithToolbox = false;
+        if (class_exists('Toolbox') && method_exists('Toolbox', 'logInFile')) {
+            Toolbox::logInFile('autoassigninternal', $line);
+
+            clearstatcache(true, $logFile);
+            if (file_exists($logFile)) {
+                $sizeAfter = filesize($logFile);
+                $wroteWithToolbox = ($sizeBefore === null && $sizeAfter > 0)
+                    || ($sizeBefore !== null && $sizeAfter !== $sizeBefore);
+            }
+        }
+
+        if ($wroteWithToolbox) {
+            return;
+        }
+
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0775, true);
+        }
+
+        if (is_dir($logDir) && is_writable($logDir)) {
+            $timestampedLine = sprintf('%s %s%s', date('Y-m-d H:i:s'), $line, PHP_EOL);
+            file_put_contents($logFile, $timestampedLine, FILE_APPEND);
+        } elseif (function_exists('error_log')) {
+            error_log($line);
+        }
+    }
+}

--- a/autoassigninternal/setup.php
+++ b/autoassigninternal/setup.php
@@ -5,10 +5,12 @@ if (!defined('GLPI_ROOT')) {
 }
 
 require_once __DIR__ . '/inc/config.class.php';
+require_once __DIR__ . '/inc/logging.php';
 
 function plugin_init_autoassigninternal() {
     global $PLUGIN_HOOKS;
 
+    $PLUGIN_HOOKS['post_item_add']['autoassigninternal'] = 'plugin_autoassigninternal_post_item_add';
     $PLUGIN_HOOKS['post_item_update']['autoassigninternal'] = 'plugin_autoassigninternal_post_item_update';
     $PLUGIN_HOOKS['config_page']['autoassigninternal'] = 'front/config.form.php';
     $PLUGIN_HOOKS['csrf_compliant']['autoassigninternal'] = true;
@@ -16,6 +18,8 @@ function plugin_init_autoassigninternal() {
     if (class_exists('Plugin')) {
         Plugin::registerClass('PluginAutoassigninternalConfig');
     }
+
+    plugin_autoassigninternal_log('Plugin AutoAssignInternal inicializado.');
 }
 
 function plugin_version_autoassigninternal() {


### PR DESCRIPTION
## Summary
- register task add/update hooks so ticket assignments are synchronized when a technician is set
- resolve the technician from users_id_tech and add detailed logging for troubleshooting
- update existing ticket-user assignments or create them to mirror the task assignee

## Testing
- php -l autoassigninternal/hook.php
- php -l autoassigninternal/setup.php

------
https://chatgpt.com/codex/tasks/task_e_68dd7936679c8331b7f6cac811686deb