### PR TITLE
Assign ticket when task technician is updated

### DIFF
--- a/AutoAssignInternal/hook.php
+++ b/AutoAssignInternal/hook.php
@@ -63,13 +63,30 @@ function plugin_AutoAssignInternal_uninstall() {
 }
 
 /**
- * Assign the ticket to the technician of the newly created task when applicable.
+ * Assign the ticket to the technician of the task based on the hook event.
  *
  * @param TicketTask $item
  */
 function plugin_AutoAssignInternal_assign_tech_on_task_add(TicketTask $item) {
-    global $DB;
+    _AutoAssignInternal_assign_tech_from_task($item, 'create');
+}
 
+/**
+ * Assign the ticket to the technician when a task is updated.
+ *
+ * @param TicketTask $item
+ */
+function plugin_AutoAssignInternal_assign_tech_on_task_update(TicketTask $item) {
+    _AutoAssignInternal_assign_tech_from_task($item, 'update');
+}
+
+/**
+ * Core logic to assign the ticket to the technician of the task.
+ *
+ * @param TicketTask $item
+ * @param string     $event
+ */
+function _AutoAssignInternal_assign_tech_from_task(TicketTask $item, string $event) {
     static $logEnabled          = null;
     static $enabledRequestTypes = null;
 
@@ -90,8 +107,10 @@ function plugin_AutoAssignInternal_assign_tech_on_task_add(TicketTask $item) {
         $ticketId = (int)$item->input['tickets_id'];
     }
 
+    $eventLabel = ($event === 'update') ? 'atualização' : 'criação';
+
     if ($logEnabled) {
-        _AutoAssignInternal_write_log(sprintf('Hook acionado para tarefa %d do chamado %d.', $taskId, $ticketId));
+        _AutoAssignInternal_write_log(sprintf('Hook de %s acionado para tarefa %d do chamado %d.', $eventLabel, $taskId, $ticketId));
     }
 
     if ($ticketId <= 0) {

--- a/AutoAssignInternal/inc/config.class.php
+++ b/AutoAssignInternal/inc/config.class.php
@@ -37,7 +37,9 @@ class PluginAutoAssignInternalConfig extends CommonDBTM {
 
         echo "<div class='center'>";
         echo "<form method='post' action=''>";
-        echo Html::hidden('_glpi_csrf_token', Session::getNewCSRFToken());
+        echo Html::hidden('_glpi_csrf_token', [
+            'value' => Session::getNewCSRFToken()
+        ]);
         echo "<table class='tab_cadre_fixe'>";
 
         echo "<tr><th colspan='2'>" . __('Configurações Gerais', 'autoassigninternal') . "</th></tr>";
@@ -73,7 +75,9 @@ class PluginAutoAssignInternalConfig extends CommonDBTM {
 
         echo "<tr class='tab_bg_2'>";
         echo "<td colspan='2' class='center'>";
-        echo Html::hidden('update', 1);
+        echo Html::hidden('update', [
+            'value' => 1
+        ]);
         echo "<input type='submit' name='submit' class='submit' value='" . _sx('button', 'Salvar') . "'>";
         echo "</td>";
         echo "</tr>";

--- a/AutoAssignInternal/setup.php
+++ b/AutoAssignInternal/setup.php
@@ -24,7 +24,8 @@ function plugin_init_AutoAssignInternal() {
 
     $PLUGIN_HOOKS['config_page']['AutoAssignInternal'] = 'front/config.form.php';
     $PLUGIN_HOOKS['csrf_compliant']['AutoAssignInternal'] = true;
-    $PLUGIN_HOOKS['item_add']['AutoAssignInternal']['TicketTask'] = 'plugin_AutoAssignInternal_assign_tech_on_task_add';
+    $PLUGIN_HOOKS['item_add']['AutoAssignInternal']['TicketTask']    = 'plugin_AutoAssignInternal_assign_tech_on_task_add';
+    $PLUGIN_HOOKS['item_update']['AutoAssignInternal']['TicketTask'] = 'plugin_AutoAssignInternal_assign_tech_on_task_update';
 
     if (class_exists('Plugin')) {
         Plugin::registerClass('PluginAutoAssignInternalConfig');


### PR DESCRIPTION
## Summary
- share the task assignment logic so it runs for both creation and update events
- register the item_update hook to trigger ticket assignment when a task technician changes
- improve debug logging to include the event context when the hook fires

## Testing
- php -l AutoAssignInternal/hook.php
- php -l AutoAssignInternal/setup.php

------
https://chatgpt.com/codex/tasks/task_e_68dd8d5e5ee08331bfe76140b9bf950c